### PR TITLE
DEVOPS-542 allow customized endpoint label

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following environment variables are used to configure global options.
 | POLL_INTERVAL | Value in milliseconds to check for rancher metadata updates | `1000` |
 | FORCE_UPDATE_INTERVAL | Value in minutes to force a resource poll. Increasing this value may be required if you run into api limits enforced by your cloud providor | `1` |
 | SERVICE_LABEL_ENDPOINT | Which label to search for elb names to update. Useful to customize if a single rancher env spans disparate cloud provider accounts, and multiple aws-elb services are required to access each one | `io.rancher.service.external_lb.endpoint` |
-| RESTRICT_SERVICE_TO_SELF_STACK | Limit service registration to those running in the same stack as the external-lb service | false |
+| RESTRICT_SERVICE_TO_SELF_STACK | Limit service registration to those running in the same stack as the external-lb service | 'false' |
 
 Contact
 ========

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following environment variables are used to configure global options.
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
 | POLL_INTERVAL | Value in milliseconds to check for rancher metadata updates | `1000` |
 | FORCE_UPDATE_INTERVAL | Value in minutes to force a resource poll. Increasing this value may be required if you run into api limits enforced by your cloud providor | `1` |
+| SERVICE_LABEL_ENDPOINT | Which label to search for elb names to update. Useful to customize if a single rancher env spans disparate cloud provider accounts, and multiple aws-elb services are required to access each one | `io.rancher.service.external_lb.endpoint` |
 
 Contact
 ========

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 external-lb
 ==========
-Rancher service facilitating integration of rancher with external load balancers. This service updates external LB with services created in Rancher that ask to be load balanced using an external LB. 
+Rancher service facilitating integration of rancher with external load balancers. This service updates external LB with services created in Rancher that ask to be load balanced using an external LB.
 Initial version comes with f5 BIG-IP support; but a pluggable provider model makes it easy to implement other providers later.
 
 Design
 ==========
-* The external-lb gets deployed as a Rancher service containerized app. 
+* The external-lb gets deployed as a Rancher service containerized app.
 
 * It enables any other service to be registered to external LB if the service has exposed a public port and has the label 'io.rancher.service.external_lb_endpoint'
 
@@ -23,6 +23,7 @@ The following environment variables are used to configure global options.
 | POLL_INTERVAL | Value in milliseconds to check for rancher metadata updates | `1000` |
 | FORCE_UPDATE_INTERVAL | Value in minutes to force a resource poll. Increasing this value may be required if you run into api limits enforced by your cloud providor | `1` |
 | SERVICE_LABEL_ENDPOINT | Which label to search for elb names to update. Useful to customize if a single rancher env spans disparate cloud provider accounts, and multiple aws-elb services are required to access each one | `io.rancher.service.external_lb.endpoint` |
+| RESTRICT_SERVICE_TO_SELF_STACK | Limit service registration to those running in the same stack as the external-lb service | false |
 
 Contact
 ========

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ const (
 	EnvVarPollInterval           = "POLL_INTERVAL"
 	EnvVarForceUpdateInterval    = "FORCE_UPDATE_INTERVAL"
 	EnvVarLBTargetRancherSuffix  = "LB_TARGET_RANCHER_SUFFIX"
+	EnvVarServiceLabelEndpoint   = "SERVICE_LABEL_ENDPOINT"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	EnvVarPollInterval        = "POLL_INTERVAL"
-	EnvVarForceUpdateInterval = "FORCE_UPDATE_INTERVAL"
+	EnvVarPollInterval         = "POLL_INTERVAL"
+	EnvVarForceUpdateInterval  = "FORCE_UPDATE_INTERVAL"
+	EnvVarServiceLabelEndpoint = "SERVICE_LABEL_ENDPOINT"
 )
 
 var (
@@ -34,6 +35,7 @@ var (
 	c        *CattleClient
 
 	targetPoolSuffix        string
+	serviceLabelEndpoint    string
 	metadataLBConfigsCached = make(map[string]model.LBConfig)
 
 	forceUpdateInterval float64
@@ -49,6 +51,14 @@ func setEnv() {
 	}
 
 	var err error
+
+	serviceLabelEndpoint = os.Getenv(EnvVarServiceLabelEndpoint)
+	if len(serviceLabelEndpoint) == 0 {
+		logrus.Info(EnvVarServiceLabelEndpoint + " is not set")
+		serviceLabelEndpoint = ""
+	} else {
+		logrus.Info(EnvVarServiceLabelEndpoint + " is set to: " + serviceLabelEndpoint)
+	}
 
 	// initialize polling and forceUpdate intervals
 	i = os.Getenv(EnvVarForceUpdateInterval)
@@ -143,7 +153,7 @@ func main() {
 
 		if update || updateForced {
 			// get records from metadata
-			metadataLBConfigs, err := m.GetMetadataLBConfigs(targetPoolSuffix)
+			metadataLBConfigs, err := m.GetMetadataLBConfigs(targetPoolSuffix, serviceLabelEndpoint)
 			if err != nil {
 				logrus.Errorf("Failed to get LB configs from metadata: %v", err)
 				continue

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	metadataURLTemplate        = "http://%v/2015-12-19"
-	serviceLabelEndpoint       = "io.rancher.service.external_lb.endpoint"
-	serviceLabelEndpointLegacy = "io.rancher.service.external_lb_endpoint"
+	metadataURLTemplate         = "http://%v/2015-12-19"
+	serviceLabelEndpointLegacy  = "io.rancher.service.external_lb_endpoint"
+	DefaultServiceLabelEndpoint = "io.rancher.service.external_lb.endpoint"
 
 	// DefaultMetadataAddress specifies the default value to use if nothing is specified
 	DefaultMetadataAddress = "169.254.169.250"
@@ -70,7 +70,10 @@ func (m *MetadataClient) GetVersion() (string, error) {
 }
 
 // GetMetadataLBConfigs ...
-func (m *MetadataClient) GetMetadataLBConfigs(targetPoolSuffix string) (map[string]model.LBConfig, error) {
+func (m *MetadataClient) GetMetadataLBConfigs(targetPoolSuffix string, serviceLabelEndpoint string) (map[string]model.LBConfig, error) {
+	if serviceLabelEndpoint == "" {
+		serviceLabelEndpoint = DefaultServiceLabelEndpoint
+	}
 	lbConfigs := make(map[string]model.LBConfig)
 	services, err := m.MetadataClient.GetServices()
 	if err != nil {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -102,7 +102,7 @@ func (m *MetadataClient) GetMetadataLBConfigs(targetPoolSuffix string, serviceLa
 			logrus.Debugf("Service %s is running in stack %s", service.Name, service.StackName)
 			logrus.Debugf("external-lb is running in stack %s", selfStack.Name)
 			if restrictServiceToSelfStack && (service.StackName != selfStack.Name) {
-				logrus.Errorf("Skipping service %s as it is running in a different stack %s than external-lb: %s",
+				logrus.Debugf("Skipping service %s as it is running in a different stack %s than external-lb: %s",
 					service.Name, service.StackName, selfStack.Name)
 				continue
 			}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -99,6 +99,8 @@ func (m *MetadataClient) GetMetadataLBConfigs(targetPoolSuffix string, serviceLa
 			}
 
 			// Skip the service if it does not exist in the desired stack (optional)
+			logrus.Debugf("Service %s is running in stack %s", service.Name, service.StackName)
+			logrus.Debugf("external-lb is running in stack %s", selfStack.Name)
 			if restrictServiceToSelfStack && (service.StackName != selfStack.Name) {
 				logrus.Errorf("Skipping service %s as it is running in a different stack %s than external-lb: %s",
 					service.Name, service.StackName, selfStack.Name)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -70,12 +70,13 @@ func (m *MetadataClient) GetVersion() (string, error) {
 }
 
 // GetMetadataLBConfigs ...
-func (m *MetadataClient) GetMetadataLBConfigs(targetPoolSuffix string, serviceLabelEndpoint string) (map[string]model.LBConfig, error) {
+func (m *MetadataClient) GetMetadataLBConfigs(targetPoolSuffix string, serviceLabelEndpoint string, restrictServiceToSelfStack bool) (map[string]model.LBConfig, error) {
 	if serviceLabelEndpoint == "" {
 		serviceLabelEndpoint = DefaultServiceLabelEndpoint
 	}
 	lbConfigs := make(map[string]model.LBConfig)
 	services, err := m.MetadataClient.GetServices()
+	selfStack, err := m.MetadataClient.GetSelfStack()
 	if err != nil {
 		logrus.Infof("Error reading services: %v", err)
 	} else {
@@ -94,6 +95,13 @@ func (m *MetadataClient) GetMetadataLBConfigs(targetPoolSuffix string, serviceLa
 			if ok {
 				logrus.Errorf("Endpoint %s already used by another service, will skip this service : %s",
 					endpoint, service.Name)
+				continue
+			}
+
+			// Skip the service if it does not exist in the desired stack (optional)
+			if restrictServiceToSelfStack && (service.StackName != selfStack.Name) {
+				logrus.Errorf("Skipping service %s as it is running in a different stack %s than external-lb: %s",
+					service.Name, service.StackName, selfStack.Name)
 				continue
 			}
 

--- a/providers/elbv1/aws_elbv1.go
+++ b/providers/elbv1/aws_elbv1.go
@@ -120,6 +120,7 @@ func (p *AWSELBv1Provider) GetLBConfigs() ([]model.LBConfig, error) {
 	}
 
 	for _, lb := range allLb {
+
 		if _, ok := lbTags[*lb.LoadBalancerName]; !ok {
 			continue
 		}
@@ -128,6 +129,13 @@ func (p *AWSELBv1Provider) GetLBConfigs() ([]model.LBConfig, error) {
 
 		var targetPoolName, servicePort string
 		var ok bool
+
+		logrus.Debugf("Working on lb %s with VPCId: %s", *lb.LoadBalancerName, *lb.VPCId)
+		if *lb.VPCId != p.vpcID {
+			logrus.Debugf("Skipping LB whose vpc %s does not match our vpc %s", *lb.VPCId, p.vpcID)
+			continue
+		}
+
 		if targetPoolName, ok = tags[TagNameTargetPool]; !ok {
 			logrus.Debugf("Skipping LB without targetPool tag: %s", *lb.LoadBalancerName)
 			continue


### PR DESCRIPTION
This supports the use-case where we have a rancher env spanning multiple aws accounts - we need the ability to target an aws-elb service to a specific set of services. Adding a custom label to the service, and allowing a customized label that aws-elb looks for, provides that functionality.